### PR TITLE
premake5: runtimechecks "Off" replaces deprecated NoRuntimeChecks flag

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -38,7 +38,7 @@ filter "configurations:Debug"
 runtime "Debug"
 symbols "on"
 optimize "speed"
-flags { "NoRuntimeChecks" }  -- /RTC1 conflicts with /O2; SDE-8 prioritizes speed
+runtimechecks "Off"  -- /RTC1 conflicts with /O2; SDE-8 prioritizes speed
 
 filter "configurations:Release"
 runtime "Release"


### PR DESCRIPTION
## Summary
- Replace deprecated `flags { "NoRuntimeChecks" }` with `runtimechecks "Off"`.

Premake5 emits a deprecation warning; the dedicated `runtimechecks` API is the documented replacement. Same compiler effect (disables `/RTC1`).

## Test plan
- [x] `premake5 vs2026` runs without the deprecation warning for this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)